### PR TITLE
drop "myclass" from css output

### DIFF
--- a/_classes.scss
+++ b/_classes.scss
@@ -21,7 +21,6 @@
 			}
 		}
 
-		[class^='myclass'], [class*=' myclass']
 		[class^='#{$sfg-prefix}col-'], [class*='#{$sfg-prefix}col-'] {
 			@include col-gutter(map-get($map, gutter));
 


### PR DESCRIPTION
Hi,

first of all thank you for your npm package and your time invested. I removed one line declaring (accidently defined?) "myclass". I didn't regenerate the dist dir, though.

best regards

Sebastian